### PR TITLE
Added Blacklist setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,19 @@ If you specify a value less than 15, it will be handled as 15 internally.
 Note that auto-update-packages does not adhere the value strictly.
 It has some margin around 5%.
 
+### Blacklist
+
+* Config Key Path: `auto-update-packages.blacklist`
+* Default: None
+* Type: CSV
+
+If, for any reason, you feel the urge to exclude some package from updating automatically,
+add its name to the **Blacklist**.
+
+Note: Separate values by commas (and optionally spaces) and use their human-friendly names, as in:
+
+`Auto Update Packages, Welcome, Asteroids` etc.
+
 ## License
 
 Copyright (c) 2014 Yuji Nakayama

--- a/lib/auto-update-packages.coffee
+++ b/lib/auto-update-packages.coffee
@@ -7,9 +7,11 @@ getFs = ->
 
 NAMESPACE = 'auto-update-packages'
 CONFIG_KEY_INTERVAL_MINUTES = 'intervalMinutes'
+CONFIG_KEY_BLACKLIST = 'blacklist'
 
 CONFIG_DEFAULTS = {}
 CONFIG_DEFAULTS[CONFIG_KEY_INTERVAL_MINUTES] = 6 * 60
+CONFIG_DEFAULTS[CONFIG_KEY_BLACKLIST] = ""
 
 WARMUP_WAIT = 10 * 1000
 MINIMUM_AUTO_UPDATE_BLOCK_DURATION_MINUTES = 15
@@ -54,11 +56,13 @@ module.exports =
 
   updatePackages: (isAutoUpdate = true) ->
     PackageUpdater ?= require './package-updater'
-    PackageUpdater.updatePackages(isAutoUpdate)
+    blacklist = atom.config.get("#{NAMESPACE}.#{CONFIG_KEY_BLACKLIST}")
+    blacklist = blacklist.split(/,\s*/)
+    PackageUpdater.updatePackages(isAutoUpdate, blacklist)
     @saveLastUpdateTime()
 
   getAutoUpdateBlockDuration: ->
-    minutes = atom.config.get([NAMESPACE, CONFIG_KEY_INTERVAL_MINUTES].join('.'))
+    minutes = atom.config.get("#{NAMESPACE}.#{CONFIG_KEY_INTERVAL_MINUTES}")
 
     if minutes < MINIMUM_AUTO_UPDATE_BLOCK_DURATION_MINUTES
       minutes = MINIMUM_AUTO_UPDATE_BLOCK_DURATION_MINUTES


### PR DESCRIPTION
Hi,

Nice package you have built, but I found myself in the need of preventing some packages from being updated automatically, so I added a **Blacklist** option.

In order to filter out packages I had to use `apm install` instead of `apm upgrade` (which does not take package names as an argument). Under the hood, apm `upgrade` uses `install` also. So right now, it is running `apm upgrade --list --json` to get a list of what updates are available and then filtering potential packages before running install.

Other than that, I have made a few CoffeeScript-cosmetic changes (feel free to neglect them) and display more human-friendly package names in the notification.

Have a good day!

PS. I have also updated the `README` if you feel like adopting it.
