### PR TITLE
:racehorse: Scope observed config by namespace

### DIFF
--- a/lib/auto-update-packages.coffee
+++ b/lib/auto-update-packages.coffee
@@ -38,7 +38,7 @@ module.exports =
       @updatePackagesIfAutoUpdateBlockIsExpired()
     , @getAutoUpdateCheckInterval()
 
-    @configSubscription = atom.config.onDidChange =>
+    @configSubscription = atom.config.onDidChange NAMESPACE, =>
       @disableAutoUpdate()
       @enableAutoUpdate()
 


### PR DESCRIPTION
This hits performance when many default configs loaded,
e.g. when package with a lot of config keys is activated.

atom-beautify has configs per supported language
and causes onDidChange to be called so many times.
https://github.com/Glavin001/atom-beautify/issues/679
