### PR TITLE
Use atom.configDirPath instead of hard coded ~/.atom path

### DIFF
--- a/lib/auto-update-packages.coffee
+++ b/lib/auto-update-packages.coffee
@@ -84,5 +84,4 @@ module.exports =
 
   getLastUpdateTimeFilePath: ->
     path ?= require 'path'
-    dotAtomPath = getFs().absolute('~/.atom')
-    path.join(dotAtomPath, 'storage', "#{NAMESPACE}-last-update-time")
+    path.join(atom.configDirPath, 'storage', "#{NAMESPACE}-last-update-time")


### PR DESCRIPTION
The path to the `ATOM_HOME` directory should never be hard coded.
